### PR TITLE
Added zf1/zend-cache dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
 	"license": "BSD-3-Clause",
 	"require": {
 		"php": ">=5.2.11",
-		"zf1/zend-exception": "self.version"
+		"zf1/zend-exception": "self.version",
+		"zf1/zend-cache": "self.version"
 	},
 	"autoload": {
 		"psr-0": {


### PR DESCRIPTION
Error: Class 'Zend_Cache' not found in vendor/zf1/zend-locale/library/Zend/Locale/Data.php line 936.
