### PR TITLE
Add Zend_Translate_Plural to autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
 	},
 	"autoload": {
 		"psr-0": {
-			"Zend_Locale": "library/"
+			"Zend_Locale": "library/",
+			"Zend_Translate_Plural": "library/"
 		}
 	},
 	"suggest": {


### PR DESCRIPTION
The `autoload_namespaces.php` file generated by composer misses `Zend_Translate_Plural`.
I _think_ that this PR should fix this
